### PR TITLE
Feature: match-default-export-name.js - name: string[] | string

### DIFF
--- a/docs/rules/match-default-export-name.md
+++ b/docs/rules/match-default-export-name.md
@@ -51,7 +51,7 @@ Properties of the objects
 | property  | required | type   | description   |
 |-----------|:--------:|--------|---------------|
 | module    |     x    | string | module name to match |
-| name      |     x    | string | default import name pattern |
+| name      |     x    | string or string[] | default import name pattern |
 | transform |          | string | transform default import name pattern to given case, can be 'camelCase', 'PascalCase' or 'snake_case' |
 
 ```json

--- a/tests/src/rules/match-default-export-name.js
+++ b/tests/src/rules/match-default-export-name.js
@@ -86,6 +86,34 @@ ruleTester.run('match-default-export-name', rule, {
       ],
     }),
     test({
+      code: 'import someComponentStyles from "./match-default-export-name/some-component.module.css";',
+      options: [
+        {
+          overrides: [
+            {
+              module: '/([\\w-]+)\\.module\\.css$/',
+              name: ['$1Styles'],
+              transform: 'camelCase',
+            },
+          ],
+        },
+      ],
+    }),
+    test({
+      code: 'import styles from "./match-default-export-name/some-component.module.css";',
+      options: [
+        {
+          overrides: [
+            {
+              module: '/([\\w-]+)\\.module\\.css$/',
+              name: ['styles', '$1Styles'],
+              transform: 'camelCase',
+            },
+          ],
+        },
+      ],
+    }),
+    test({
       code: 'import id from "./match-default-export-name/id";',
       options: [
         {
@@ -233,6 +261,42 @@ ruleTester.run('match-default-export-name', rule, {
       ],
       errors: [{
         message: 'Expected import \'css\' to match \'someComponentStyles\'.',
+        type: 'ImportDefaultSpecifier',
+      }],
+    }),
+    test({
+      code: 'import css from "./match-default-export-name/some-component.module.css";',
+      options: [
+        {
+          overrides: [
+            {
+              module: '/([\\w-]+)\\.module\\.css$/',
+              name: ['$1Styles'],
+              transform: 'camelCase',
+            },
+          ],
+        },
+      ],
+      errors: [{
+        message: 'Expected import \'css\' to match \'someComponentStyles\'.',
+        type: 'ImportDefaultSpecifier',
+      }],
+    }),
+    test({
+      code: 'import css from "./match-default-export-name/some-component.module.css";',
+      options: [
+        {
+          overrides: [
+            {
+              module: '/([\\w-]+)\\.module\\.css$/',
+              name: ['styles', '$1Styles'],
+              transform: 'camelCase',
+            },
+          ],
+        },
+      ],
+      errors: [{
+        message: 'Expected import \'css\' to match \'styles\' or \'someComponentStyles\'.',
         type: 'ImportDefaultSpecifier',
       }],
     }),


### PR DESCRIPTION
Добавил возможность указывать массив строк или просто строку в overrides.name